### PR TITLE
fixes parenthesis for print necessary for python 3.x

### DIFF
--- a/image_analogy/losses/patch_matcher.py
+++ b/image_analogy/losses/patch_matcher.py
@@ -179,9 +179,9 @@ if __name__ == '__main__':
         #print end-start
     start = time.time()
     result = matcher.get_reconstruction(patches=matcher.target_patches)
-    print result.shape
+    print(result.shape)
     end = time.time()
-    print end-start
+    print(end-start)
     outimg = deprocess_image(result, contrast_percent=0)
     # # imsave takes (rows, cols, channels)
     imsave(output_prefix + '_best.png', outimg)


### PR DESCRIPTION
On startup of the script, tehre is an error because of missing parenthesis at 
... image_analogy\losses\patch_matcher.py", line 182
    print result.shape

Turns out that the parenthesis for print are necessary in python 3.x, which I (and maybe some others) have.