### PR TITLE
Fix for issue #39.

### DIFF
--- a/image_analogy/vgg16.py
+++ b/image_analogy/vgg16.py
@@ -7,6 +7,8 @@ from keras.layers.convolutional import (
     AveragePooling2D, Convolution2D, MaxPooling2D, ZeroPadding2D)
 from keras.models import Sequential
 
+from keras import __version__ as keras_version
+from distutils.version import StrictVersion
 
 def img_from_vgg(x):
     '''Decondition an image from the VGG16 model.'''
@@ -83,6 +85,22 @@ def get_model(img_width, img_height, weights_path='vgg16_weights.h5', pool_mode=
             break
         g = f['layer_{}'.format(k)]
         weights = [g['param_{}'.format(p)] for p in range(g.attrs['nb_params'])]
+
+        # Check if your version of keras version '2.0.0' or above.
+        if StrictVersion(keras_version) >= StrictVersion('2.0.0'):
+            # If your version of keras version '2.0.0' or above,
+            # then 
+            # 1. convert each element x of the list 'weights'
+            #    into a numpy array, 
+            # 2. transpose each of those arrays, and
+            # 3. save the list of transposed arrays back to
+            #    the 'weights' list.
+            weights_T = [np.array(x).T for x in weights]
+            weights = weights_T            
+        
+        # else, leave the 'weights' list unchanged
+        # leave the elements of 'weights' untransposed.
+
         layer = model.layers[k]
         if isinstance(layer, Convolution2D):
             weights[0] = np.array(weights[0])[:, :, ::-1, ::-1]

--- a/image_analogy/vgg16.py
+++ b/image_analogy/vgg16.py
@@ -86,9 +86,9 @@ def get_model(img_width, img_height, weights_path='vgg16_weights.h5', pool_mode=
         g = f['layer_{}'.format(k)]
         weights = [g['param_{}'.format(p)] for p in range(g.attrs['nb_params'])]
 
-        # Check if your version of keras version '2.0.0' or above.
+        # Check if your version of keras is version '2.0.0' or above.
         if StrictVersion(keras_version) >= StrictVersion('2.0.0'):
-            # If your version of keras version '2.0.0' or above,
+            # If your version of keras is version '2.0.0' or above,
             # then 
             # 1. convert each element x of the list 'weights'
             #    into a numpy array, 


### PR DESCRIPTION
This pull request is intended to fix issue #39 (ValueError: Layer weight shape (3, 3, 3, 64) not compatible with provided weight shape (64, 3, 3, 3) ) and to make the image-analogies package compatible with keras versions 2.0.0 and above.

I only made changes to the vgg16.py file.  

The newly added code does the following:
1. It checks if your version of keras is version '2.0.0' or above;
2. If your version of keras is version '2.0.0' or above, then it (1) converts each element x of the list 'weights' into a numpy array, (2) transposes each of those arrays, and (3) saves the list of transposed arrays back to the 'weights' list. 

            weights_T = [np.array(x).T for x in weights]
            weights = weights_T            

3. If your version of keras is version not '2.0.0' or above, the 'weights' list is left unchanged; the elements of 'weights' are left untransposed.

Transposing the weights is necessary for compatibility with keras is version '2.0.0' or above.

The code should still be compatible with earlier versions of keras before version '2.0.0'.