### PR TITLE
Fix inconsistent Bash file names in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ e.g.:
 
 `make_image_analogy.py images/arch-mask.jpg images/arch.jpg images/arch-newmask.jpg out/arch`
 
-The examples directory has a script, `render_example.sh` which accepts an example
+The examples directory has a script, `render-example.sh` which accepts an example
 name prefix and, optionally the location of your vgg weights.
 
-`./render_example.sh arch /path/to/your/weights.h5`
+`./render-example.sh arch /path/to/your/weights.h5`
 
 Currently, A and A' must be the same size, the same holds for B and B'.
 Output size is the same as Image B, unless specified otherwise.


### PR DESCRIPTION
## e649ad1 Fix inconsistent Bash file names in README.md

The Bash file names appear in the latter part of "Installation" section
of the `README.md` file have to be in "kebab-case" (hyphen-separated
case) instead of "snake_case", in order for them to be consistent with
the actual file names in the `examples` directory.

---

### Message from the collaborator

Please review my commit and if necessary, rectify as appropriate.

Thank you!

sho